### PR TITLE
Add new method .unsubscribe on the async iterator object.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ describe('some examples', () => {
 
     yield iter.shouldComplete();
       // Will throw if onNext or onError are produced.
+
+    iter.unsubscribe();
+      // Use this if ending the test before the Observable terminates and you
+      // want to ensure proper resource cleanup. This is not necessary if you
+      // reach an onComplete or onError state in a successful test.
   });
 
   it('has a shortcut form for an Observable that produces a single value', function *() {

--- a/index.js
+++ b/index.js
@@ -9,84 +9,107 @@ const doneSentinel = {};
  * function yielding the same results.
  */
 
-const toAsyncIterator = function *(observable) {
-  let isDone = false;
+class AsyncIterator {
+  constructor (observable) {
+    this._observable = observable;
+  }
 
-  let pendingCallback;
-  let pendingValues = [];
-    // TO DO: Look for a more efficient queue implementation.
+  * iter () {
+    let isDone = false;
 
-  const callTheCallback = (callback, pendingValue) => {
-    if (pendingValue.value === doneSentinel) {
-      isDone = true;
-    }
-    callback(pendingValue.err, pendingValue.value);
-  };
+    let pendingCallback;
+    let pendingValues = [];
+      // TO DO: Look for a more efficient queue implementation.
 
-  const produce = pendingValue => {
-    if (pendingCallback) {
-      const cb = pendingCallback;
-      pendingCallback = null;
-      callTheCallback(cb, pendingValue);
-    } else {
-      pendingValues.push(pendingValue);
-    }
-  };
+    const callTheCallback = (callback, pendingValue) => {
+      if (pendingValue.value === doneSentinel) {
+        isDone = true;
+      }
+      callback(pendingValue.err, pendingValue.value);
+    };
 
-  observable.subscribe(
-    value => produce({err: null, value: value}),
-    err => produce({err: err, value: null}),
-    () => produce({err: null, value: doneSentinel}));
-
-  // TO DO: What should we do with subscriptionHandle?
-  // IOW, how to detect if client loses interest?
-
-  const consumeViaCallback = () => {
-    return cb => {
-      let item = pendingValues.shift();
-      if (item === undefined) {
-        pendingCallback = cb;
+    const produce = pendingValue => {
+      if (pendingCallback) {
+        const cb = pendingCallback;
+        pendingCallback = null;
+        callTheCallback(cb, pendingValue);
       } else {
-        callTheCallback(cb, item);
+        pendingValues.push(pendingValue);
       }
     };
-  };
 
-  while (!isDone) {
-    yield consumeViaCallback();
-  }
-};
+    this._subscribeHandle = this._observable.subscribe(
+      value => produce({err: null, value: value}),
+      err => produce({err: err, value: null}),
+      () => produce({err: null, value: doneSentinel}));
 
-toAsyncIterator.prototype.nextValue = function *() {
-  let item = yield this.next();
-  if (item.value === doneSentinel) {
-    throw new Error('Expected onNext notification, got onCompleted instead');
-  }
-  return item.value;
-};
+    const consumeViaCallback = () => {
+      return cb => {
+        let item = pendingValues.shift();
+        if (item === undefined) {
+          pendingCallback = cb;
+        } else {
+          callTheCallback(cb, item);
+        }
+      };
+    };
 
-toAsyncIterator.prototype.shouldComplete = function *() {
-  let item = yield this.next();
-  if (item.value !== doneSentinel) {
-    throw new Error('Expected onCompleted notification, got onNext(' + item.value + ') instead');
-  }
-};
-
-toAsyncIterator.prototype.shouldThrow = function *() {
-  let item;
-
-  try {
-    item = yield this.next();
-  } catch (err) {
-    return err;
+    while (!isDone) {
+      yield consumeViaCallback();
+    }
   }
 
-  if (item.value === doneSentinel) {
-    throw new Error('Expected onError notification, got onCompleted instead');
-  } else {
-    throw new Error('Expected onError notification, got onNext(' + item.value + ') instead');
+  makeIter () {
+    let result = this.iter();
+
+    result.nextValue = function *() {
+      let item = yield this._iter.next();
+      if (item.value === doneSentinel) {
+        throw new Error('Expected onNext notification, got onCompleted instead');
+      }
+      return item.value;
+    }.bind(this);
+
+    result.shouldComplete = function *() {
+      let item = yield this._iter.next();
+      if (item.value !== doneSentinel) {
+        throw new Error('Expected onCompleted notification, got onNext(' + item.value + ') instead');
+      }
+    }.bind(this);
+
+    result.shouldThrow = function *() {
+      let item;
+
+      try {
+        item = yield this._iter.next();
+      } catch (err) {
+        return err;
+      }
+
+      if (item.value === doneSentinel) {
+        throw new Error('Expected onError notification, got onCompleted instead');
+      } else {
+        throw new Error('Expected onError notification, got onNext(' + item.value + ') instead');
+      }
+    }.bind(this);
+
+    result.unsubscribe = function () {
+      if (this._subscribeHandle === undefined) {
+        throw new Error('toAsyncIterator: unsubscribing before first yield not allowed');
+      }
+
+      // Quietly ignore second unsubscribe attempt.
+
+      if (this._subscribeHandle) {
+        this._subscribeHandle.dispose();
+        this._subscribeHandle = false;
+      }
+    }.bind(this);
+
+    this._iter = result;
+    return result;
   }
-};
+}
 
 Rx.Observable.prototype.shouldBeEmpty = function *() {
   yield this.toAsyncIterator().shouldComplete();
@@ -109,5 +132,6 @@ Rx.Observable.prototype.shouldThrow = function *() {
  */
 
 Rx.Observable.prototype.toAsyncIterator = function () {
-  return toAsyncIterator(this);
+  const iter = new AsyncIterator(this);
+  return iter.makeIter();
 };

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const doneSentinel = {};
  * function yielding the same results.
  */
 
-const toAsyncIterator = module.exports = function *(observable) {
+const toAsyncIterator = function *(observable) {
   let isDone = false;
 
   let pendingCallback;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rx-to-async-iterator",
-  "version": "1.1.8",
+  "version": "1.2.0",
   "description": "Convert RxJS Observable streams to async iterators",
   "main": "index.js",
   "scripts": {

--- a/test/testCoreApi.js
+++ b/test/testCoreApi.js
@@ -5,12 +5,14 @@ const Rx = require('rx');
 const chai = require('chai');
 const expect = chai.expect;
 
-const toAsyncIterator = require('../index');
+const taiValue = require('../index'); // ... has side-effect of adding toAsyncIterator operator
 
 describe('rx-to-async-iterator', () => {
-  it('should be defined as a function', () => {
-    expect(toAsyncIterator).to.be.a('function');
-      // WARNING: We don't test this API independently. It might go away.
+  it('should not export any value', () => {
+    expect(taiValue).to.deep.equal({});
+      // IMPORTANT: Change from v1.1.8. The previous syntax was unsupported
+      // and undocumented and it broke with Node 6.0, so I'm formally
+      // decomissioning it now.
   });
 
   it('should patch Rx.Observable to add toAsyncIterator operator', () => {


### PR DESCRIPTION
Also drop the previously-undocumented and unsupported functional form of this API.

(Merge from rx-to-async-iterator v1.2.0. See tangledfruit/rx-to-async-iterator#19.)
